### PR TITLE
Move pluck to collections module

### DIFF
--- a/krump/sentence/sentence_mongo.py
+++ b/krump/sentence/sentence_mongo.py
@@ -3,14 +3,11 @@
 from flask import current_app
 
 from krump import required_value
+from krump.support.collections import pluck
 
 
 def get_sentences(request):
     return list(map(pluck('sentence'), sentences().find().limit(request['count'])))
-
-
-def pluck(field):
-    return lambda s: s[field]
 
 
 def sentences():

--- a/krump/support/collections.py
+++ b/krump/support/collections.py
@@ -6,3 +6,7 @@ Collections-related utility methods.
 
 def has_elements(l):
     return l is not None and len(l) > 0
+
+
+def pluck(field):
+    return lambda s: s[field]

--- a/test/krump/support/collections_tests.py
+++ b/test/krump/support/collections_tests.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from krump.support.collections import pluck
+
+
+class PluckTests(unittest.TestCase):
+    def test_pluck_with_key_that_exists(self):
+        self.assertEqual('Adam', pluck('name')(dict(name='Adam')))
+
+    def test_pluck_with_key_that_does_not_exist(self):
+        self.assertRaises(KeyError, lambda: pluck('name')(dict()))


### PR DESCRIPTION
It's a generic function and so doesn't belong in an application-specific repository module.

I also added `nose` as a dependency because it was missing :blush: