### PR TITLE
Implement max-words support in the /sentence API

### DIFF
--- a/features/sentences.feature
+++ b/features/sentences.feature
@@ -23,3 +23,17 @@ Feature: Give me some sentences
 		Then these sentences are returned
 			| sentence              |
 			| Adam's car is lovely. |
+
+
+	Scenario: We can limit sentences by number of words
+
+		Given these sentences exist
+			| sentence                                                     | features   |
+			| Adam's car is lovely.                                        | apostrophe |
+			| Adam's goat cheese pancakes are to die for.                  | apostrophe |
+			| The glory of Adam's breakfasts is toast with a bacon coulis. | apostrophe |
+		When we request sentences with the 'apostrophe' feature and a maximum of 9 words
+		Then these sentences are returned
+			| sentence                                    |
+			| Adam's car is lovely.                       |
+			| Adam's goat cheese pancakes are to die for. |

--- a/features/steps/sentences.py
+++ b/features/steps/sentences.py
@@ -22,6 +22,11 @@ def request_for_one_sentence(context, feature):
     context.response = context.sentence_api.get_sentences(feature, count=1)
 
 
+@when("we request sentences with the '(?P<feature>.+?)' feature and a maximum of (?P<max_words>\d+?) words")
+def request_for_sentences_with_maximum_words(context, feature, max_words):
+    context.response = context.sentence_api.get_sentences(feature, max_words=max_words)
+
+
 @then("these sentences are returned")
 def these_sentences_are_returned(context):
     assert_status_code_ok(context.response)

--- a/krump/sentence/sentence_mongo.py
+++ b/krump/sentence/sentence_mongo.py
@@ -6,7 +6,13 @@ from krump import required_value
 
 
 def get_sentences(request):
-    return list(map(pluck('sentence'), sentences().find().limit(request['count'])))
+    query = {}
+
+    maximum_words = request.get('maximum_words', None)
+    if maximum_words is not None:
+        query['$where'] = 'this.words.length <= {}'.format(maximum_words)
+
+    return list(map(pluck('sentence'), sentences().find(query).limit(request['count'])))
 
 
 def pluck(field):


### PR DESCRIPTION
Uses Mongo's `$where` operator which parses a JavaScript conditional expression on the fly.

Let's look at this again if we ever get a _lot_ of data in the DB. For now it's fine.