### PR TITLE
Display sentences in a nice HTML page

### DIFF
--- a/krump/support/collections.py
+++ b/krump/support/collections.py
@@ -10,3 +10,12 @@ def has_elements(l):
 
 def pluck(field):
     return lambda s: s[field]
+
+
+def copy_and_update(source, **updates):
+    assert source is not None, 'The source is required.'
+
+    result = source.copy()
+    if updates:
+        result.update(updates)
+    return result

--- a/krump/support/web/filters.py
+++ b/krump/support/web/filters.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+
+def json_pretty(data):
+    return json.dumps(data, indent=2)

--- a/krump/support/web/resolvers.py
+++ b/krump/support/web/resolvers.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from krump import has_text, KrumpException
+from krump.support.collections import has_elements
+
+
+class CannotFindViewException(KrumpException):
+    """
+    Thrown in response to failing to find a named view.
+    """
+
+    def __init__(self, message, cause=None):
+        super(CannotFindViewException, self).__init__(message, cause)
+
+    @staticmethod
+    def for_view_name(view_name, cause=None):
+        """
+        Return a C{CannotFindViewException} instance with a helpful message
+        built using the supplied C{view_name}.
+
+        @param view_name: the name of the view that cannot be found.
+        @param cause: the root cause, if any.
+        @return: a C{CannotFindViewException} instance; never C{None}.
+        """
+
+        message = 'Cannot find the view named "{}"; did you map it?'.format(view_name)
+        return CannotFindViewException(message, cause=cause)
+
+    @staticmethod
+    def for_missing_view_name(cause=None):
+        """
+        Return a C{CannotFindViewException} instance with a helpful message.
+
+        @param cause: the root cause, if any.
+        @return: a C{CannotFindViewException} instance; never C{None}.
+        """
+
+        message = 'No view name supplied.'
+        return CannotFindViewException(message, cause=cause)
+
+
+class SimpleMappingBasedViewResolver(object):
+    # noinspection PyUnusedLocal
+    def resolve_view(self, *args, **kwargs):
+        view_name = kwargs[self.view_name_key]
+        if view_name in self.view_mappings:
+            view = self.view_mappings[view_name]
+            if not view:
+                raise CannotFindViewException(
+                    'View for [{}] resolved to [None]; check configuration.'.format(view_name))
+            return view
+        elif has_text(view_name):
+            raise CannotFindViewException.for_view_name(view_name)
+        else:
+            raise CannotFindViewException.for_missing_view_name(view_name)
+
+    def __init__(self, view_mappings, view_name_key='view_name'):
+        super(SimpleMappingBasedViewResolver, self).__init__()
+
+        assert has_elements(view_mappings), 'The view mappings are required.'
+        assert has_text(view_name_key), 'The view name key is required.'
+
+        self.view_mappings = view_mappings
+        self.view_name_key = view_name_key
+
+
+class SimpleSuffixBasedViewResolver(object):
+    """
+    Resolve a logical view name to a (file)path by appending a suffix.
+
+    Forex, the logical view name 'login' becomes 'login.html' with a suffix of '.html'.
+    """
+
+    # noinspection PyUnusedLocal
+    def resolve_view(self, *args, **kwargs):
+        """
+        Resolve the logical view name to a (file)path by appending a suffix.
+
+        @param args: ignored.
+        @param kwargs: contains the logical view name.
+        @return: the resolved (file)path.
+        """
+
+        if self.view_name_key in kwargs:
+            logical_view_name = kwargs[self.view_name_key]
+            if has_text(logical_view_name):
+                view_name = '{}{}'.format(logical_view_name, self.suffix)
+                return view_name
+            else:
+                raise CannotFindViewException.for_missing_view_name()
+        else:
+            raise CannotFindViewException(
+                'No view name found in model using key [{}]; check configuration.'.format(self.view_name_key))
+
+    def __init__(self, suffix='.html', view_name_key='view_name'):
+        """
+        Create a C{SimpleSuffixBasedViewResolver}.
+
+        @param suffix: the suffix to be appended to the logical view name; must not be C{None}.
+        @param view_name_key: the name of the logical view name in the model; must not be C{None}.
+        """
+
+        super(SimpleSuffixBasedViewResolver, self).__init__()
+
+        assert has_text(suffix), 'The suffix is required.'
+        assert has_text(view_name_key), 'The view name key is required.'
+
+        self.suffix = suffix
+        self.view_name_key = view_name_key

--- a/krump/templates/layouts/main.html
+++ b/krump/templates/layouts/main.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block page_title %}Sentence Factory{% endblock %}</title>
+  <link rel="stylesheet"
+        href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/default.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+</head>
+<body>
+
+<div class="container">
+  {% block body %}{% endblock %}
+</div>
+
+</body>
+</html>
+
+<body>

--- a/krump/templates/sentence.html
+++ b/krump/templates/sentence.html
@@ -1,0 +1,6 @@
+{% extends "layouts/main.html" %}
+{% block body %}
+
+<pre><code class="js">{{sentences | pretty}}</code></pre>
+
+{% endblock %}

--- a/test/krump/support/collections_tests.py
+++ b/test/krump/support/collections_tests.py
@@ -2,7 +2,9 @@
 
 import unittest
 
-from krump.support.collections import pluck
+from hamcrest import *
+
+from krump.support.collections import pluck, copy_and_update
 
 
 class PluckTests(unittest.TestCase):
@@ -11,3 +13,39 @@ class PluckTests(unittest.TestCase):
 
     def test_pluck_with_key_that_does_not_exist(self):
         self.assertRaises(KeyError, lambda: pluck('name')(dict()))
+
+
+# noinspection PyMethodMayBeStatic
+class CopyAndUpdateTests(unittest.TestCase):
+    def test_sunny_day_kwargs(self):
+        source = dict(foo=3)
+        result = copy_and_update(source, bar=3)
+        assert_that(result, not_none())
+        assert_that(result, has_key('foo'))
+        assert_that(result, has_key('bar'))
+
+    def test_sunny_day_overrides_correctly(self):
+        source = dict(foo=3)
+        expected_value = 4
+        result = copy_and_update(source, foo=expected_value)
+        assert_that(result, not_none())
+        assert_that(result, has_key('foo'))
+        self.assertEquals(expected_value, result['foo'])
+
+    def test_sunny_day_dict(self):
+        source = dict(foo=3)
+        updates = dict(bar=3)
+        result = copy_and_update(source, **updates)
+        assert_that(result, not_none())
+        assert_that(result, has_key('foo'))
+        assert_that(result, has_key('bar'))
+
+    def test_missing_source(self):
+        assert_that(calling(copy_and_update).with_args(None), raises(AssertionError))
+
+    def test_missing_updates(self):
+        source = dict(foo=3)
+        result = copy_and_update(source)
+        assert_that(result, not_none())
+        assert_that(result, has_key('foo'))
+        assert_that(result, has_length(1))

--- a/test/krump/support/web/resolvers_tests.py
+++ b/test/krump/support/web/resolvers_tests.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from hamcrest import *
+
+from krump.support.web.resolvers import *
+
+
+# noinspection PyMethodMayBeStatic
+class SimpleSuffixBasedViewResolverTests(unittest.TestCase):
+    def test_ctor_with_defaults(self):
+        SimpleSuffixBasedViewResolver()
+
+    def test_ctor_with_custom_suffix(self):
+        SimpleSuffixBasedViewResolver(suffix='.txt')
+
+    def test_ctor_with_none_suffix(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(suffix=None)
+
+    def test_ctor_with_empty_suffix(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(suffix='')
+
+    def test_ctor_with_whitespace_suffix(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(suffix='  ')
+
+    def test_ctor_with_none_view_name_key(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(view_name_key=None)
+
+    def test_ctor_with_empty_view_name_key(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(view_name_key='')
+
+    def test_ctor_with_whitespace_view_name_key(self):
+        with self.assertRaises(AssertionError):
+            SimpleSuffixBasedViewResolver(view_name_key='  ')
+
+    def test_resolve_view_with_defaults(self):
+        logical_view_name = 'login'
+
+        resolver = SimpleSuffixBasedViewResolver()
+        view_name = resolver.resolve_view(view_name=logical_view_name)
+        assert_that(view_name, is_('login.html'))
+
+    def test_resolve_view_with_custom_suffix(self):
+        logical_view_name = 'login'
+
+        resolver = SimpleSuffixBasedViewResolver(suffix='.txt')
+        view_name = resolver.resolve_view(view_name=logical_view_name)
+        assert_that(view_name, is_('login.txt'))
+
+    def test_resolve_view_with_custom_suffix_and_custom_view_name_key(self):
+        logical_view_name = 'login'
+
+        resolver = SimpleSuffixBasedViewResolver(suffix='.txt', view_name_key='logical_view')
+        view_name = resolver.resolve_view(logical_view=logical_view_name)
+        assert_that(view_name, is_('login.txt'))
+
+    def test_resolve_view_with_missing_logical_view_name(self):
+        with self.assertRaises(CannotFindViewException):
+            resolver = SimpleSuffixBasedViewResolver()
+            resolver.resolve_view(missing=None)
+
+    def test_resolve_view_with_none_logical_view_name(self):
+        with self.assertRaises(CannotFindViewException):
+            resolver = SimpleSuffixBasedViewResolver()
+            resolver.resolve_view(view_name=None)
+
+
+# noinspection PyMethodMayBeStatic
+class SimpleMappingBasedViewResolverTests(unittest.TestCase):
+    def test_ctor_with_none_view_mappings(self):
+        with self.assertRaises(AssertionError):
+            SimpleMappingBasedViewResolver(None)
+
+    def test_ctor_with_empty_view_mappings(self):
+        with self.assertRaises(AssertionError):
+            SimpleMappingBasedViewResolver(dict())
+
+    def test_resolve_view_sunny_day(self):
+        resolver = SimpleMappingBasedViewResolver(dict(foo='bar'))
+        view_name = resolver.resolve_view(view_name='foo')
+        assert_that(view_name, is_('bar'))
+
+    def test_resolve_view_missing(self):
+        with self.assertRaises(CannotFindViewException):
+            resolver = SimpleMappingBasedViewResolver(dict(foo='bar'))
+            resolver.resolve_view(view_name='not_here')
+
+    def test_resolve_view_empty(self):
+        with self.assertRaises(CannotFindViewException):
+            resolver = SimpleMappingBasedViewResolver(dict(foo=''))
+            resolver.resolve_view(view_name='foo')


### PR DESCRIPTION
If you run the application and then surf to:

http://localhost:9000/api/sentence/apostrophe

... you'll see the resulting data displayed as pretty-printed JSON.

![nice](https://cloud.githubusercontent.com/assets/1855109/21521298/a22bf976-ccf3-11e6-9a24-29ba6a81ec50.png)

I have *not* written a cuke test to prove this 'cos it's just rendering a page with no real functionality being tested.