### PR TITLE
add paging feature via skip query param

### DIFF
--- a/krump/sentence/mongo.py
+++ b/krump/sentence/mongo.py
@@ -62,6 +62,7 @@ def _get_sentences(request, query):
                        )
     sentences = sentences_collection() \
         .find(query, projections) \
+        .skip(request['skip'] * request['count']) \
         .limit(request['count']) \
         .sort('_id', -1)
     return list(sentences)

--- a/krump/sentence/to_request.py
+++ b/krump/sentence/to_request.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
 PARAMETER_COUNT = 'count'
+PARAMETER_SKIP = 'skip'
 PARAMETER_MAXIMUM_WORDS = 'max-words'
 
 DEFAULT_COUNT = 10
+DEFAULT_SKIP = 0
+MAXIMUM_SKIP = 100
 MAXIMUM_WORDS = 100
 MAXIMUM_COUNT = 1000
 
@@ -28,9 +31,12 @@ def to_count(raw_count):
 def to_maximum_words(raw_maximum_words):
     return None if raw_maximum_words is None else to_bounded_int(None, MAXIMUM_WORDS, raw_maximum_words)
 
+def to_skip(raw_skip_count):
+    return to_bounded_int(DEFAULT_SKIP, MAXIMUM_SKIP, raw_skip_count)
 
 def to_request_for_sentences(request, **kwargs):
     return dict(
         kwargs,
         count=to_count(request.args.get(PARAMETER_COUNT, DEFAULT_COUNT)),
-        maximum_words=to_maximum_words(request.args.get(PARAMETER_MAXIMUM_WORDS, None)))
+        maximum_words=to_maximum_words(request.args.get(PARAMETER_MAXIMUM_WORDS, None)),
+        skip=to_skip(request.args.get(PARAMETER_SKIP, DEFAULT_SKIP)))

--- a/test/krump/sentence/to_request_tests.py
+++ b/test/krump/sentence/to_request_tests.py
@@ -17,7 +17,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -26,7 +27,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            word='free'
+            word='free',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -35,7 +37,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=2,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -44,7 +47,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=2,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -53,16 +57,26 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=33,
             maximum_words=2,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
+
+    def test_to_request_with_feature_and_count_and_maximum_words_and_skip(self):
+        actual_request = to_request(stub_request('count=33&max-words=2&skip=2'), feature='modal')
+        expected_request = dict(
+            count=33,
+            maximum_words=2,
+            feature='modal',
+            skip=2)
 
     def test_to_request_imposes_maximum_on_count(self):
         actual_request = to_request(stub_request('count=123456'), feature='modal')
         expected_request = dict(
             count=1000,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -71,7 +85,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=100,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -80,7 +95,8 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -89,16 +105,26 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
+
+    def test_to_request_imposes_lower_bound_when_skip_is_zero(self):
+        actual_request = to_request(stub_request('skip=0'), feature='modal')
+        expected_request = dict(
+            count=10,
+            maximum_words=None,
+            feature='modal',
+            skip=0)
 
     def test_to_request_imposes_lower_bound_when_count_is_negative(self):
         actual_request = to_request(stub_request('count=-6534'), feature='modal')
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -107,16 +133,26 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
+
+    def test_to_request_imposes_lower_bound_when_skip_is_negative(self):
+        actual_request = to_request(stub_request('skip=-6534'), feature='modal')
+        expected_request = dict(
+            count=10,
+            maximum_words=None,
+            feature='modal',
+            skip=0)
 
     def test_to_request_imposes_default_when_count_is_malformed(self):
         actual_request = to_request(stub_request('count=Sixteen%20Horsepower'), feature='modal')
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
 
@@ -125,6 +161,15 @@ class ToRequestForSentencesTests(unittest.TestCase):
         expected_request = dict(
             count=10,
             maximum_words=None,
-            feature='modal'
+            feature='modal',
+            skip=0
         )
         self.assertDictEqual(expected_request, actual_request)
+
+    def test_to_request_imposes_default_when_skip_is_malformed(self):
+        actual_request = to_request(stub_request('skip=Tosh'), feature='modal')
+        expected_request = dict(
+            count=10,
+            maximum_words=None,
+            feature='modal',
+            skip=0)


### PR DESCRIPTION
Added in a skip query param with the intention of allowing people to get the second/third/fourth/etc 10 (or however many) sentences. Seems to be working on my local tests, though admittedly I have no formal tests written to prove that my user tests are correct. Happy to work on that if it's a condition of getting accepted into the codebase, though assuming I would need a lot more help than I did with this feature.

Very happy to discuss any changes that need doing, though already did a check for tab/space formatting, so at least that should pass code review this time! lurz